### PR TITLE
Accommodate changes in REPL and Pkg loading in Julia 1.11 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BasicAutoloads"
 uuid = "09cdc199-4954-42dd-9e0c-2e47e8233053"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [compat]
 julia = "1"

--- a/src/BasicAutoloads.jl
+++ b/src/BasicAutoloads.jl
@@ -64,8 +64,8 @@ function (al::_Autoload)(@nospecialize(expr))
     expr
 end
 function try_autoinstall(expr::Expr)
-    isdefined(Base, :active_repl) || return
-    REPL = typeof(Base.active_repl).name.module
+    isdefined(Base, :active_repl_backend) || return
+    REPL = typeof(Base.active_repl_backend).name.module
     isdefined(REPL, :install_packages_hooks) || return
     expr.head in (:using, :import) || return
     for arg in expr.args

--- a/src/BasicAutoloads.jl
+++ b/src/BasicAutoloads.jl
@@ -64,13 +64,15 @@ function (al::_Autoload)(@nospecialize(expr))
     expr
 end
 function try_autoinstall(expr::Expr)
-    REPL = Base.loaded_modules[Base.PkgId(Base.UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb"), "REPL")]
+    isdefined(Base, :active_repl) || return
+    REPL = typeof(Base.active_repl).name.module
     isdefined(REPL, :install_packages_hooks) || return
     expr.head in (:using, :import) || return
     for arg in expr.args
         arg isa Expr && arg.head == :. && length(arg.args) == 1 || continue
         mod = only(arg.args)
         mod isa Symbol && Base.identify_package(String(mod)) === nothing || continue
+        isempty(REPL.install_packages_hooks) && isdefined(REPL, :load_pkg) && REPL.load_pkg()
         for f in REPL.install_packages_hooks
             Base.invokelatest(f, [mod]) && break
         end


### PR DESCRIPTION
- Get REPL by inspecting the type of Base.active_repl instead of inspecting the list of loaded packages becuase in 1.11, REPL can be loaded and still not in Base.loaded_modules
- Follow REPL by loading pkg if it has not been already so that the package install prompt works even if a user hasn't entered pkg mode
- Bump Version

Fixes #7 