### PR TITLE
Unpack QuoteNodes

### DIFF
--- a/src/BasicAutoloads.jl
+++ b/src/BasicAutoloads.jl
@@ -49,6 +49,8 @@ end
 function (al::_Autoload)(@nospecialize(expr))
     if expr isa Expr
         foreach(al, expr.args)
+    elseif expr isa QuoteNode
+        al(expr.value)
     elseif expr isa Symbol
         target = get(al.dict, expr, nothing)
         target === nothing && return expr


### PR DESCRIPTION
Fixes #10.

```julia-repl
julia> BasicAutoloads.register_autoloads([
               ["@profile"] => :(using Profile, PProf),
           ])

julia> Profile.Allocs.@profile 1+1
 │ Package PProf not found, but a package named PProf is available from a registry. 
 │ Install package?
 │   (@v1.11) pkg> add PProf 
 └ (y/n/o) [y]: y
   Resolving package versions...
   Installed BufferedStreams ─ v1.2.2
   Installed Pango_jll ─────── v1.54.0+0
   Installed pprof_jll ─────── v1.0.1+0
   Installed PProf ─────────── v3.1.3
   Installed FileIO ────────── v1.16.4
   Installed ProtoBuf ──────── v1.0.16
  Downloaded artifact: Pango
  Downloaded artifact: pprof
    Updating `~/.julia/environments/v1.11/Project.toml`
  [e4faabce] + PProf v3.1.3
    Updating `~/.julia/environments/v1.11/Manifest.toml`
  [1520ce14] + AbstractTrees v0.4.5
  [e1450e63] + BufferedStreams v1.2.2
  [4e289a0a] + EnumX v1.0.4
  [5789e2e9] + FileIO v1.16.4
  [08572546] + FlameGraphs v1.0.0
  [9b13fd28] + IndirectArrays v1.0.0
  [1d6d02ad] + LeftChildRightSiblingTrees v0.2.0
  [e4faabce] + PProf v3.1.3
  [92933f4c] + ProgressMeter v1.10.2
  [3349acd9] + ProtoBuf v1.0.16
  [3c863552] + Graphviz_jll v2.50.0+1
⌃ [36c8627f] + Pango_jll v1.54.0+0
  [cf2c5f97] + pprof_jll v1.0.1+0
        Info Packages marked with ⌃ have new versions available and may be upgradable.
Precompiling PProf...
  13 dependencies successfully precompiled in 6 seconds. 78 already precompiled.
2
```