### PR TITLE
Longer timeout and better warnings when waiting for the REPL to load

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BasicAutoloads"
 uuid = "09cdc199-4954-42dd-9e0c-2e47e8233053"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
-version = "1.0.2"
+version = "1.0.3"
 
 [compat]
 julia = "1"

--- a/src/BasicAutoloads.jl
+++ b/src/BasicAutoloads.jl
@@ -112,6 +112,7 @@ function (wrat::_WaitRegisterASTTransform)()
         end
     else
         @warn "Timed out waiting to Base.active_repl_backend to be defined. Autoloads will not work."
+        @info "If you have a slow startup file, consider moving `register_autoloads` to the end of it."
     end
 end
 

--- a/src/BasicAutoloads.jl
+++ b/src/BasicAutoloads.jl
@@ -100,14 +100,18 @@ struct _WaitRegisterASTTransform{T}
 end
 function (wrat::_WaitRegisterASTTransform)()
     iter = 0
-    while !isdefined(Base, :active_repl_backend) && iter < 20
-        sleep(.05)
+    while !isdefined(Base, :active_repl_backend) && iter < 30
         iter += 1
+        sleep(.02*iter)
     end
-    if isdefined(Base, :active_repl_backend) && isdefined(Base.active_repl_backend, :ast_transforms)
-        pushfirst!(Base.active_repl_backend.ast_transforms, wrat.ast_transform)
+    if isdefined(Base, :active_repl_backend)
+        if isdefined(Base.active_repl_backend, :ast_transforms)
+            pushfirst!(Base.active_repl_backend.ast_transforms, wrat.ast_transform)
+        else
+            @warn "Failed to find Base.active_repl_backend.ast_transforms. Autoloads will not work."
+        end
     else
-        @warn "Failed to find Base.active_repl_backend.ast_transforms"
+        @warn "Timed out waiting to Base.active_repl_backend to be defined. Autoloads will not work."
     end
 end
 


### PR DESCRIPTION
I doubt many folks are going to have startup files that take more than 9.3 seconds to run. That would be ridiculous. If so, and only in that case, we'll suggest putting the registration at the end of the file and plant that suggestion in a very prominent place (their repl).

Implements @danielwe's suggestions https://github.com/LilithHafner/BasicAutoloads.jl/issues/9#issuecomment-2513215047 and https://github.com/LilithHafner/BasicAutoloads.jl/issues/9#issuecomment-2513221362