### PR TITLE
Clean up example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ For example, put this in your startup.jl
 
 ```julia
 if isinteractive()
-    import BasicAutoloads
-    BasicAutoloads.register_autoloads([
+    using BasicAutoloads
+    register_autoloads([
         ["@b", "@be"]            => :(using Chairmarks),
         ["@benchmark"]           => :(using BenchmarkTools),
         ["@test", "@testset", "@test_broken", "@test_deprecated", "@test_logs",


### PR DESCRIPTION
Thanks for providing the package! These are really nitpicks. I would appreciate a short explanation in case you reject it. Ideally either the code gets slightly better or there is something to learn.

- `using` instead of `import` as the user typically adds no methods to `register_autoloads`
- Use exported `register_autoloads` without its FQN. Otherwise it could be `public`, but `register_autoloads` seems to be rate enough to not conflict typically